### PR TITLE
Add Graph RAG Traces end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ RAG Playground is a full-stack retrieval-augmented generation sandbox. It pairs 
 - **UI**: when `NEXT_PUBLIC_GRAPH_RAG_ENABLED=true`, the playground shows a “Graph RAG (multi-stage)” mode with controls for k, hops, rerank (CE/LLM), verification, and live sub-query diagnostics.
 - Graph data lives alongside the existing per-session index, so no additional infrastructure is required. Re-indexing a session rebuilds the graph idempotently.
 
+### Graph RAG Traces
+- Each advanced Graph RAG query now captures a structured trace detailing the planner output, retrieval diagnostics, rerank decisions, per-sub-query summaries, verification notes, and final synthesis metadata. The API response adds a `request_id` plus a `trace` payload, and you can re-fetch the trace later via `GET /api/query/advanced/trace/{session_id}/{request_id}` for debugging or demos.
+- A new runtime flag `features.graph_traces_enabled` (Firestore or `GRAPH_TRACES_ENABLED` env var) gates trace capture. It defaults to `true` and surfaces via `/api/health/details` as `graph_rag_traces_enabled` so the web app can toggle UI affordances without redeploying.
+- In the playground’s Graph RAG mode a **Show trace** toggle reveals a timeline viewer summarizing planner steps, retrieval hits, rerank stats, verification verdicts, and the synthesized answer. The viewer also exposes a **Download JSON** button to grab the raw trace for deep dives.
+
 ## Prerequisites
 - Python 3.11 with [Poetry](https://python-poetry.org/)
 - Node.js 18+ with [pnpm](https://pnpm.io/) v8+

--- a/apps/api/app/routers/health.py
+++ b/apps/api/app/routers/health.py
@@ -7,6 +7,7 @@ from ..services.runtime_config import (
     get_runtime_config,
     get_runtime_config_metadata,
     google_auth_enabled_effective,
+    graph_traces_enabled_effective,
 )
 
 router = APIRouter()
@@ -37,6 +38,7 @@ async def health_details():
         "google_auth_effective": google_auth_enabled_effective(),
         "graph_enabled": features.graph_enabled,
         "advanced_graph_enabled": features.graph_enabled,
+        "graph_rag_traces_enabled": graph_traces_enabled_effective(),
         "advanced_llm_enabled": llm_capable,
         "llm_rerank_enabled": features.llm_rerank_enabled and llm_capable,
         "fact_check_llm_enabled": features.fact_check_llm_enabled and llm_capable,

--- a/apps/api/app/routers/query_advanced.py
+++ b/apps/api/app/routers/query_advanced.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from ..schemas import AdvancedQueryRequest, AdvancedQueryResponse
+from ..schemas import AdvancedQueryRequest, AdvancedQueryResponse, GraphRagTrace
 from ..services.advanced import run_advanced_query
 from ..services.runtime_config import get_runtime_config
 from ..services.session_auth import SessionUser, get_session_user, maybe_require_auth
+from ..services.traces import get_trace
 
 router = APIRouter()
 
@@ -28,3 +29,22 @@ async def query_advanced(
     except ValueError as err:
         raise HTTPException(status_code=400, detail=str(err)) from err
     return result
+
+
+@router.get("/query/advanced/trace/{session_id}/{request_id}", response_model=GraphRagTrace)
+async def get_advanced_trace(
+    session_id: str,
+    request_id: str,
+    user: SessionUser | None = Depends(get_session_user),
+):
+    maybe_require_auth(user)
+    runtime_cfg = get_runtime_config()
+    features = runtime_cfg.features
+    if not features.graph_enabled:
+        raise HTTPException(status_code=404, detail="Advanced graph mode is disabled.")
+    if not features.graph_traces_enabled:
+        raise HTTPException(status_code=404, detail="Graph RAG trace capture is disabled.")
+    trace = get_trace(session_id, request_id)
+    if not trace:
+        raise HTTPException(status_code=404, detail="Trace not found.")
+    return trace

--- a/apps/api/app/schemas.py
+++ b/apps/api/app/schemas.py
@@ -115,11 +115,93 @@ class VerificationSummary(BaseModel):
     notes: str
 
 
+class GraphRagTraceConfig(BaseModel):
+    k: int
+    max_hops: int
+    temperature: float
+    rerank_strategy: str
+    verification_mode: str
+    model: str
+    max_subqueries: int
+
+
+class GraphRagTracePlannerStep(BaseModel):
+    id: int
+    text: str
+    stage: str = "sub-query"
+    tags: List[str] = []
+
+
+class GraphRagTracePlanner(BaseModel):
+    sub_queries: List[GraphRagTracePlannerStep]
+    notes: Optional[str] = None
+
+
+class GraphRagTraceDocument(BaseModel):
+    doc_id: str
+    chunk_index: int
+    rank: int
+    snippet: Optional[str] = None
+    dense_score: Optional[float] = None
+    lexical_score: Optional[float] = None
+    fused_score: Optional[float] = None
+    rerank_score: Optional[float] = None
+
+
+class GraphRagTraceRetrieval(BaseModel):
+    sub_query: str
+    documents: List[GraphRagTraceDocument]
+    graph_paths: List[Dict[str, Any]]
+    metrics: Dict[str, float | int]
+
+
+class GraphRagTraceRerank(BaseModel):
+    strategy: str
+    latency_ms: float
+    top_documents: List[GraphRagTraceDocument]
+
+
+class GraphRagTraceSummary(BaseModel):
+    text: str
+    citations: List[str]
+
+
+class GraphRagTraceSubQueryTrace(BaseModel):
+    id: int
+    query: str
+    retrieval: GraphRagTraceRetrieval
+    rerank: Optional[GraphRagTraceRerank] = None
+    summary: GraphRagTraceSummary
+    warnings: List[str] = []
+
+
+class GraphRagTraceSynthesis(BaseModel):
+    answer: str
+    citations: List[Dict[str, Any]]
+    model: str
+    notes: Optional[str] = None
+
+
+class GraphRagTrace(BaseModel):
+    request_id: str
+    session_id: str
+    query: str
+    timestamp: str
+    config: GraphRagTraceConfig
+    planner: GraphRagTracePlanner
+    subqueries: List[GraphRagTraceSubQueryTrace]
+    verification: Optional[VerificationSummary] = None
+    synthesis: GraphRagTraceSynthesis
+    warnings: List[str] = []
+
+
 class AdvancedQueryResponse(BaseModel):
     session_id: str
+    request_id: str
     query: str
     planner: Dict[str, Any]
     subqueries: List[AdvancedSubQuery]
     answer: str
     citations: List[Dict[str, Any]]
     verification: Optional[VerificationSummary] = None
+    trace: Optional[GraphRagTrace] = None

--- a/apps/api/app/services/runtime_config.py
+++ b/apps/api/app/services/runtime_config.py
@@ -25,6 +25,7 @@ class FeatureFlags(BaseModel):
     llm_rerank_enabled: bool = False
     fact_check_llm_enabled: bool = False
     fact_check_strict: bool = False
+    graph_traces_enabled: bool = True
 
 
 class RuntimeConfig(BaseModel):
@@ -49,6 +50,7 @@ _FEATURE_FIELDS = (
     "llm_rerank_enabled",
     "fact_check_llm_enabled",
     "fact_check_strict",
+    "graph_traces_enabled",
 )
 _GRAPH_FIELDS = (
     "max_graph_hops",
@@ -56,6 +58,7 @@ _GRAPH_FIELDS = (
     "advanced_default_k",
     "advanced_default_temperature",
 )
+_OPTIONAL_FEATURE_FIELDS = {"graph_traces_enabled"}
 
 
 def _env_bool(names: Tuple[str, ...], default: bool) -> bool:
@@ -100,6 +103,7 @@ def _load_env_config(config_env: str) -> RuntimeConfig:
         llm_rerank_enabled=_env_bool(("LLM_RERANK_ENABLED", "RAG_LLM_RERANK_ENABLED"), False),
         fact_check_llm_enabled=_env_bool(("FACT_CHECK_LLM_ENABLED", "RAG_FACT_CHECK_LLM_ENABLED"), False),
         fact_check_strict=_env_bool(("FACT_CHECK_STRICT", "RAG_FACT_CHECK_STRICT"), False),
+        graph_traces_enabled=_env_bool(("GRAPH_TRACES_ENABLED", "RAG_GRAPH_TRACES_ENABLED"), True),
     )
     graph_config = GraphRagConfig(
         max_graph_hops=_env_int("MAX_GRAPH_HOPS", 2),
@@ -142,7 +146,7 @@ def _detect_missing_fields(doc: Dict[str, Any]) -> List[str]:
     missing: List[str] = []
     features = doc.get("features") or {}
     for field in _FEATURE_FIELDS:
-        if features.get(field) is None:
+        if features.get(field) is None and field not in _OPTIONAL_FEATURE_FIELDS:
             missing.append(f"features.{field}")
     graph = doc.get("graph_rag") or {}
     for field in _GRAPH_FIELDS:
@@ -269,6 +273,10 @@ def fact_check_llm_enabled_effective() -> bool:
 
 def fact_check_strict_effective() -> bool:
     return get_runtime_config().features.fact_check_strict
+
+
+def graph_traces_enabled_effective() -> bool:
+    return get_runtime_config().features.graph_traces_enabled
 
 
 def max_graph_hops_effective() -> int:

--- a/apps/api/app/services/traces.py
+++ b/apps/api/app/services/traces.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+from collections import OrderedDict
+from threading import Lock
+from typing import Tuple
+
+from ..schemas import GraphRagTrace
+
+
+class TraceStore:
+    """In-memory Graph RAG trace store (non-persistent, best-effort)."""
+
+    def __init__(self, max_entries: int = 200):
+        self._max_entries = max_entries
+        self._lock = Lock()
+        self._data: OrderedDict[Tuple[str, str], GraphRagTrace] = OrderedDict()
+
+    def put(self, trace: GraphRagTrace) -> None:
+        key = (trace.session_id, trace.request_id)
+        with self._lock:
+            self._data[key] = trace
+            self._data.move_to_end(key)
+            while len(self._data) > self._max_entries:
+                self._data.popitem(last=False)
+
+    def get(self, session_id: str, request_id: str) -> GraphRagTrace | None:
+        key = (session_id, request_id)
+        with self._lock:
+            trace = self._data.get(key)
+            if trace is not None:
+                self._data.move_to_end(key)
+            return trace
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+
+
+def _default_cache_size() -> int:
+    raw = os.getenv("GRAPH_TRACE_CACHE_SIZE")
+    if not raw:
+        return 200
+    try:
+        return max(20, int(raw))
+    except ValueError:
+        return 200
+
+
+_TRACE_STORE = TraceStore(max_entries=_default_cache_size())
+
+
+def store_trace(trace: GraphRagTrace) -> None:
+    _TRACE_STORE.put(trace)
+
+
+def get_trace(session_id: str, request_id: str) -> GraphRagTrace | None:
+    return _TRACE_STORE.get(session_id, request_id)
+
+
+def clear_traces() -> None:
+    _TRACE_STORE.clear()

--- a/apps/api/tests/test_runtime_config.py
+++ b/apps/api/tests/test_runtime_config.py
@@ -110,3 +110,17 @@ def test_runtime_config_google_auth_env_override(monkeypatch):
     monkeypatch.delenv("FIRESTORE_CONFIG_ENABLED", raising=False)
     monkeypatch.delenv("GOOGLE_AUTH_ENABLED", raising=False)
     runtime_config.reload_runtime_config()
+
+
+def test_graph_traces_flag_env_override(monkeypatch):
+    runtime_config.clear_runtime_config_override()
+    monkeypatch.setenv("FIRESTORE_CONFIG_ENABLED", "false")
+    monkeypatch.setenv("GRAPH_TRACES_ENABLED", "false")
+    runtime_config.reload_runtime_config()
+    assert runtime_config.graph_traces_enabled_effective() is False
+    monkeypatch.setenv("GRAPH_TRACES_ENABLED", "true")
+    runtime_config.reload_runtime_config()
+    assert runtime_config.graph_traces_enabled_effective() is True
+    monkeypatch.delenv("GRAPH_TRACES_ENABLED", raising=False)
+    monkeypatch.delenv("FIRESTORE_CONFIG_ENABLED", raising=False)
+    runtime_config.reload_runtime_config()

--- a/apps/web/components/GraphRagTraceViewer.tsx
+++ b/apps/web/components/GraphRagTraceViewer.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import React, { useCallback, useMemo } from "react";
+
+import type { GraphRagTrace } from "../lib/types";
+
+type GraphRagTraceViewerProps = {
+  trace: GraphRagTrace;
+};
+
+function formatTimestamp(ts: string) {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return ts;
+  }
+}
+
+export default function GraphRagTraceViewer({ trace }: GraphRagTraceViewerProps) {
+  const formattedTs = useMemo(() => formatTimestamp(trace.timestamp), [trace.timestamp]);
+  const configItems = useMemo(
+    () => [
+      { label: "k", value: trace.config.k },
+      { label: "Max hops", value: trace.config.max_hops },
+      { label: "Max sub-queries", value: trace.config.max_subqueries },
+      { label: "Temperature", value: trace.config.temperature },
+      { label: "Rerank", value: trace.config.rerank_strategy.toUpperCase() },
+      { label: "Verification", value: trace.config.verification_mode.toUpperCase() },
+      { label: "Model", value: trace.config.model },
+    ],
+    [trace.config],
+  );
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([JSON.stringify(trace, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `graph-trace-${trace.request_id}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [trace]);
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-800 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Graph RAG Trace</h3>
+          <p className="text-xs text-slate-500">Captured {formattedTs}</p>
+          <p className="text-xs text-slate-500">Request {trace.request_id.slice(0, 8)}…</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleDownload}
+          className="rounded-md border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+        >
+          Download JSON
+        </button>
+      </div>
+
+      {trace.warnings.length ? (
+        <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900">
+          <div className="font-semibold">Warnings</div>
+          <ul className="list-disc pl-4">
+            {trace.warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <dl className="mt-4 grid gap-3 text-xs text-slate-600 sm:grid-cols-2 lg:grid-cols-3">
+        <div>
+          <dt className="font-semibold text-slate-700">Query</dt>
+          <dd className="text-slate-900">{trace.query}</dd>
+        </div>
+        {configItems.map((item) => (
+          <div key={item.label}>
+            <dt className="font-semibold text-slate-700">{item.label}</dt>
+            <dd className="text-slate-900">{item.value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <section className="mt-5">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Planner</h4>
+        <ol className="mt-2 space-y-2">
+          {trace.planner.sub_queries.map((sub) => (
+            <li key={sub.id} className="rounded border border-slate-200 bg-slate-50 p-2">
+              <div className="text-xs font-semibold text-slate-600">
+                Step {sub.id} · {sub.stage}
+              </div>
+              <div className="text-sm text-slate-900">{sub.text}</div>
+              {sub.tags?.length ? (
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {sub.tags.map((tag) => (
+                    <span key={tag} className="rounded-full bg-white px-2 py-0.5 text-[11px] text-slate-500">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="mt-5 space-y-4">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Pipeline</h4>
+        {trace.subqueries.map((sub) => (
+          <div key={sub.id} className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <div className="text-sm font-semibold text-slate-900">
+                  Sub-query {sub.id}: {sub.query}
+                </div>
+                <p className="text-xs text-slate-500">
+                  Graph paths: {sub.retrieval.graph_paths.length} · Documents: {sub.retrieval.documents.length}
+                </p>
+              </div>
+              {sub.warnings.length ? (
+                <span className="rounded border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] text-amber-800">
+                  {sub.warnings.join(" · ")}
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-3 grid gap-3 lg:grid-cols-3">
+              <div className="rounded border border-white bg-white/80 p-2 text-xs text-slate-600 shadow">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Retrieval</div>
+                <ul className="mt-2 space-y-1">
+                  {sub.retrieval.documents.length ? (
+                    sub.retrieval.documents.map((doc) => (
+                      <li key={`${sub.id}-${doc.chunk_index}-${doc.rank}`}>
+                        <div className="text-[11px] text-slate-500">
+                          [{doc.rank}] {doc.doc_id.slice(0, 8)}… · chunk #{doc.chunk_index}
+                        </div>
+                        <div className="text-sm text-slate-900 line-clamp-3">{doc.snippet}</div>
+                        <div className="text-[11px] text-slate-400">
+                          dense={doc.dense_score?.toFixed(2) ?? "-"} · lexical={doc.lexical_score?.toFixed(2) ?? "-"} ·
+                          rerank={doc.rerank_score?.toFixed(2) ?? "-"}
+                        </div>
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-slate-400">No documents returned.</li>
+                  )}
+                </ul>
+                <div className="mt-2 text-[11px] text-slate-400">
+                  Hops {sub.retrieval.metrics.hops_used ?? "-"} · Graph hits {sub.retrieval.metrics.graph_candidates ?? "-"} ·
+                  Hybrid hits {sub.retrieval.metrics.hybrid_candidates ?? "-"}
+                </div>
+              </div>
+              <div className="rounded border border-white bg-white/80 p-2 text-xs text-slate-600 shadow">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Rerank</div>
+                {sub.rerank ? (
+                  <>
+                    <p className="text-sm text-slate-900">
+                      Strategy {sub.rerank.strategy.toUpperCase()} · {sub.rerank.latency_ms.toFixed(1)} ms
+                    </p>
+                    <ul className="mt-2 space-y-1">
+                      {sub.rerank.top_documents.map((doc) => (
+                        <li key={`${sub.id}-rerank-${doc.chunk_index}-${doc.rank}`} className="text-[11px] text-slate-500">
+                          {doc.doc_id.slice(0, 8)}… score {doc.rerank_score?.toFixed(2) ?? "-"}
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                ) : (
+                  <p className="text-sm text-slate-400">No rerank scores for this sub-query.</p>
+                )}
+              </div>
+              <div className="rounded border border-white bg-white/80 p-2 text-xs text-slate-600 shadow">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Summary</div>
+                <p className="text-sm text-slate-900 whitespace-pre-line">{sub.summary.text}</p>
+                <div className="mt-2 text-[11px] text-slate-500">
+                  Citations: {sub.summary.citations.length ? sub.summary.citations.join(", ") : "None"}
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </section>
+
+      <section className="mt-5 grid gap-3 lg:grid-cols-2">
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+          <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Verification</div>
+          {trace.verification ? (
+            <div className="mt-2 text-sm text-slate-900">
+              <div className="font-semibold text-purple-700">{trace.verification.verdict.toUpperCase()}</div>
+              <div className="text-xs text-slate-600">
+                Mode {trace.verification.mode.toUpperCase()} · Coverage {(trace.verification.coverage * 100).toFixed(0)}%
+              </div>
+              <p className="mt-1 text-sm text-slate-800">{trace.verification.notes}</p>
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500">Verification disabled for this run.</p>
+          )}
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+          <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Synthesis</div>
+          <p className="text-sm text-slate-900 whitespace-pre-line">{trace.synthesis.answer}</p>
+          <div className="mt-2 text-[11px] text-slate-500">
+            Model {trace.synthesis.model} · Citations {trace.synthesis.citations.length}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/lib/__tests__/apiBaseUrl.test.ts
+++ b/apps/web/lib/__tests__/apiBaseUrl.test.ts
@@ -18,16 +18,11 @@ assert.equal(
   "values should be trimmed",
 );
 
-assert.equal(
-  resolveApiBase(customEnv("")),
-  "https://rag-playground-api-908840126213.us-west1.run.app",
-  "empty values fall back to the Cloud Run API URL",
-);
+assert.equal(resolveApiBase(customEnv("")), "http://localhost:8000", "empty values fall back to localhost:8000");
 
 assert.equal(
   resolveApiBase(),
-  process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, "") ||
-    "https://rag-playground-api-908840126213.us-west1.run.app",
+  process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, "") || "http://localhost:8000",
   "default env lookup should match runtime behavior",
 );
 

--- a/apps/web/lib/__tests__/graphTraceViewer.test.tsx
+++ b/apps/web/lib/__tests__/graphTraceViewer.test.tsx
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToString } from "react-dom/server";
+
+import GraphRagTraceViewer from "../../components/GraphRagTraceViewer";
+import type { GraphRagTrace } from "../../lib/types";
+
+const sampleTrace: GraphRagTrace = {
+  request_id: "req-unit",
+  session_id: "sess-123",
+  query: "How many PTO references exist?",
+  timestamp: new Date().toISOString(),
+  config: {
+    k: 3,
+    max_hops: 2,
+    temperature: 0.2,
+    rerank_strategy: "ce",
+    verification_mode: "ragv",
+    model: "gpt-4o-mini",
+    max_subqueries: 2,
+  },
+  planner: {
+    sub_queries: [{ id: 1, text: "Find PTO policy details", stage: "sub-query", tags: ["root"] }],
+    notes: null,
+  },
+  subqueries: [
+    {
+      id: 1,
+      query: "Find PTO policy details",
+      retrieval: {
+        sub_query: "Find PTO policy details",
+        documents: [
+          {
+            doc_id: "doc-1",
+            chunk_index: 0,
+            rank: 1,
+            snippet: "PTO policy references remote guidelines.",
+            dense_score: 0.9,
+            lexical_score: 0.6,
+            fused_score: 0.75,
+            rerank_score: 0.88,
+          },
+        ],
+        graph_paths: [],
+        metrics: { hops_used: 1, graph_candidates: 2, hybrid_candidates: 3 },
+      },
+      rerank: {
+        strategy: "ce",
+        latency_ms: 12.5,
+        top_documents: [
+          {
+            doc_id: "doc-1",
+            chunk_index: 0,
+            rank: 1,
+            snippet: "PTO policy references remote guidelines.",
+            rerank_score: 0.88,
+          },
+        ],
+      },
+      summary: { text: "PTO policy references remote guidelines. [S1]", citations: ["S1"] },
+      warnings: [],
+    },
+  ],
+  verification: {
+    mode: "ragv",
+    verdict: "supported",
+    coverage: 1,
+    notes: "All claims supported.",
+  },
+  synthesis: {
+    answer: "Final answer",
+    citations: [{ id: "S1" }],
+    model: "gpt-4o-mini",
+    notes: null,
+  },
+  warnings: [],
+};
+
+const html = renderToString(<GraphRagTraceViewer trace={sampleTrace} />);
+
+assert(html.includes("Graph RAG Trace"));
+assert(html.includes("Find PTO policy details"));
+assert(html.includes("PTO policy"));
+
+console.log("✅ Graph trace viewer renders without crashing");

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,13 +1,14 @@
 type EnvLike = Record<string, string | undefined> | NodeJS.ProcessEnv;
 
-const FALLBACK_API_BASE_URL = "https://rag-playground-api-908840126213.us-west1.run.app";
+const DEFAULT_LOCAL_API_BASE_URL = "http://localhost:8000";
 
 export function resolveApiBase(env: EnvLike = process.env): string {
   const cleaned = env?.NEXT_PUBLIC_API_BASE_URL?.trim();
   if (!cleaned) {
-    return FALLBACK_API_BASE_URL;
+    return DEFAULT_LOCAL_API_BASE_URL;
   }
-  return cleaned.replace(/\/$/, "") || FALLBACK_API_BASE_URL;
+  const normalized = cleaned.replace(/\/$/, "");
+  return normalized || DEFAULT_LOCAL_API_BASE_URL;
 }
 
 const API_BASE_URL = resolveApiBase();

--- a/apps/web/lib/rag-api.ts
+++ b/apps/web/lib/rag-api.ts
@@ -8,6 +8,7 @@ import type {
   AuthUser,
   CompareRequest,
   CompareResult,
+  GraphRagTrace,
   HealthDetails,
   IndexResponse,
   MetricsResponse,
@@ -230,4 +231,16 @@ export async function queryAdvancedGraph(body: AdvancedQueryPayload): Promise<Ad
     throw new Error(await res.text());
   }
   return (await res.json()) as AdvancedQueryResponse;
+}
+
+export async function fetchGraphTrace(sessionId: string, requestId: string): Promise<GraphRagTrace> {
+  const res = await fetch(`${getApiBaseUrl()}/api/query/advanced/trace/${sessionId}/${requestId}`, {
+    method: "GET",
+    credentials: "include",
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return (await res.json()) as GraphRagTrace;
 }

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -110,6 +110,7 @@ export type HealthDetails = {
   llm_available: boolean;
   answer_mode_default: string;
   version?: string;
+  graph_rag_traces_enabled?: boolean;
 };
 
 export type AdvancedRetrievedMeta = {
@@ -144,10 +145,92 @@ export type AdvancedVerificationSummary = {
 
 export type AdvancedQueryResponse = {
   session_id: string;
+  request_id: string;
   query: string;
   planner: Record<string, unknown>;
   subqueries: AdvancedSubQueryResult[];
   answer: string;
   citations: Array<Record<string, unknown>>;
   verification?: AdvancedVerificationSummary | null;
+  trace?: GraphRagTrace | null;
+};
+
+export type GraphRagTraceConfig = {
+  k: number;
+  max_hops: number;
+  temperature: number;
+  rerank_strategy: string;
+  verification_mode: string;
+  model: string;
+  max_subqueries: number;
+};
+
+export type GraphRagTracePlannerStep = {
+  id: number;
+  text: string;
+  stage: string;
+  tags?: string[];
+};
+
+export type GraphRagTracePlanner = {
+  sub_queries: GraphRagTracePlannerStep[];
+  notes?: string | null;
+};
+
+export type GraphRagTraceDocument = {
+  doc_id: string;
+  chunk_index: number;
+  rank: number;
+  snippet?: string | null;
+  dense_score?: number | null;
+  lexical_score?: number | null;
+  fused_score?: number | null;
+  rerank_score?: number | null;
+};
+
+export type GraphRagTraceRetrieval = {
+  sub_query: string;
+  documents: GraphRagTraceDocument[];
+  graph_paths: Array<Record<string, unknown>>;
+  metrics: Record<string, number>;
+};
+
+export type GraphRagTraceRerank = {
+  strategy: string;
+  latency_ms: number;
+  top_documents: GraphRagTraceDocument[];
+};
+
+export type GraphRagTraceSummary = {
+  text: string;
+  citations: string[];
+};
+
+export type GraphRagTraceSubQueryTrace = {
+  id: number;
+  query: string;
+  retrieval: GraphRagTraceRetrieval;
+  rerank?: GraphRagTraceRerank | null;
+  summary: GraphRagTraceSummary;
+  warnings: string[];
+};
+
+export type GraphRagTraceSynthesis = {
+  answer: string;
+  citations: Array<Record<string, unknown>>;
+  model: string;
+  notes?: string | null;
+};
+
+export type GraphRagTrace = {
+  request_id: string;
+  session_id: string;
+  query: string;
+  timestamp: string;
+  config: GraphRagTraceConfig;
+  planner: GraphRagTracePlanner;
+  subqueries: GraphRagTraceSubQueryTrace[];
+  verification?: AdvancedVerificationSummary | null;
+  synthesis: GraphRagTraceSynthesis;
+  warnings: string[];
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test:sanity": "tsx lib/__tests__/modePayload.test.ts && tsx lib/__tests__/apiBaseUrl.test.ts"
+    "test:sanity": "tsx lib/__tests__/modePayload.test.ts && tsx lib/__tests__/apiBaseUrl.test.ts && tsx lib/__tests__/graphTraceViewer.test.tsx"
   },
   "dependencies": {
     "@rag-playground/shared": "workspace:*",


### PR DESCRIPTION
## Summary
- add structured Graph RAG trace capture + runtime flag + trace endpoint on the API
- surface trace data in advanced responses/health details and add README docs
- add the Graph trace viewer/toggle on the playground with download + trace fetch fallback

## Testing
- cd apps/api && SESSION_SECRET=local-test-secret poetry run pytest -q
- cd apps/web && pnpm --filter web test:sanity

## Config
- new optional GRAPH_TRACES_ENABLED / features.graph_traces_enabled flag (default true)