### PR TITLE
Graph RAG traces v2 – inline explainability

### DIFF
--- a/apps/api/app/schemas.py
+++ b/apps/api/app/schemas.py
@@ -115,6 +115,40 @@ class VerificationSummary(BaseModel):
     notes: str
 
 
+class GraphRagTracePlannerStep(BaseModel):
+    subquery: str
+    hop: int
+    notes: Optional[str] = None
+
+
+class GraphRagTraceRetrievalHit(BaseModel):
+    doc_id: Optional[str] = None
+    source: Optional[str] = None
+    score: Optional[float] = None
+    rank: Optional[int] = None
+    snippet: Optional[str] = None
+
+
+class GraphRagTraceVerificationResult(BaseModel):
+    verdict: str
+    reason: Optional[str] = None
+
+
+class GraphRagTraceSynthesisNote(BaseModel):
+    step: str
+    notes: Optional[str] = None
+
+
+class GraphRagTrace(BaseModel):
+    request_id: str
+    mode: str
+    planner_steps: List[GraphRagTracePlannerStep] = []
+    retrieval_hits: List[GraphRagTraceRetrievalHit] = []
+    verification: Optional[GraphRagTraceVerificationResult] = None
+    synthesis_notes: List[GraphRagTraceSynthesisNote] = []
+    warnings: List[str] = []
+
+
 class AdvancedQueryResponse(BaseModel):
     session_id: str
     query: str
@@ -123,3 +157,4 @@ class AdvancedQueryResponse(BaseModel):
     answer: str
     citations: List[Dict[str, Any]]
     verification: Optional[VerificationSummary] = None
+    trace: Optional[GraphRagTrace] = None

--- a/apps/web/app/playground/page.tsx
+++ b/apps/web/app/playground/page.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import AdvancedSettings from "../../components/AdvancedSettings";
 import FeedbackBar from "../../components/FeedbackBar";
+import GraphRagTraceViewer from "../../components/GraphRagTraceViewer";
 import HealthBadge from "../../components/HealthBadge";
 import MetricsDrawer from "../../components/MetricsDrawer";
 import Uploader from "../../components/Uploader";
@@ -27,6 +28,7 @@ import type {
   AnswerMode,
   CompareProfile,
   ConfidenceLevel,
+  GraphRagTrace,
   HealthDetails,
   RetrievedChunk,
   RetrievedPrelude,
@@ -184,6 +186,8 @@ const [queryId, setQueryId] = useState<string | null>(null);
     verificationMode: "ragv" as "none" | "ragv" | "llm",
   });
   const [graphResult, setGraphResult] = useState<AdvancedQueryResponse | null>(null);
+  const [graphTrace, setGraphTrace] = useState<GraphRagTrace | null>(null);
+  const [showGraphTrace, setShowGraphTrace] = useState(false);
 
   useEffect(() => {
     if (process.env.NODE_ENV !== "production") {
@@ -442,6 +446,8 @@ const [queryId, setQueryId] = useState<string | null>(null);
     setAnswerComplete(false);
     setSources([]);
     setGraphResult(null);
+    setGraphTrace(null);
+    setShowGraphTrace(false);
     setError(null);
     const sanitizedRerank = graphSettings.rerank === "llm" && !LLM_RERANK_ALLOWED ? "ce" : graphSettings.rerank;
     const sanitizedVerification =
@@ -476,9 +482,12 @@ const [queryId, setQueryId] = useState<string | null>(null);
       );
       setSources(normalizedSources);
       setGraphResult(response);
+      setGraphTrace(response.trace ?? null);
+      setShowGraphTrace(false);
     } catch (err: any) {
       setError(friendlyError(err));
       setGraphResult(null);
+      setGraphTrace(null);
     } finally {
       setBusy("idle");
     }
@@ -1085,6 +1094,29 @@ const [queryId, setQueryId] = useState<string | null>(null);
                 <div>Coverage: {(graphResult.verification.coverage * 100).toFixed(0)}%</div>
                 <div className="text-gray-700">{graphResult.verification.notes}</div>
               </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {mode === "graph" ? (
+          <div className="mt-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setShowGraphTrace((prev) => !prev)}
+                disabled={!graphTrace}
+                className="rounded border border-gray-300 px-3 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+              >
+                {showGraphTrace ? "Hide trace" : "Show trace"}
+              </button>
+              {graphTrace ? (
+                <span className="text-[11px] text-gray-500">Trace ID: {graphTrace.request_id.slice(0, 8)}…</span>
+              ) : (
+                <span className="text-[11px] text-gray-400">Trace unavailable for this run.</span>
+              )}
+            </div>
+            {showGraphTrace && graphTrace ? (
+              <GraphRagTraceViewer trace={graphTrace} />
             ) : null}
           </div>
         ) : null}

--- a/apps/web/components/GraphRagTraceViewer.tsx
+++ b/apps/web/components/GraphRagTraceViewer.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import React, { useCallback } from "react";
+
+import type { GraphRagTrace } from "../lib/types";
+
+function formatHop(step: { hop: number; subquery: string }) {
+  return `Hop ${step.hop + 1}: ${step.subquery}`;
+}
+
+type Props = {
+  trace: GraphRagTrace;
+};
+
+export default function GraphRagTraceViewer({ trace }: Props) {
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([JSON.stringify(trace, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `graph-trace-${trace.request_id}.json`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }, [trace]);
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-800 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-slate-500">Trace</div>
+          <div className="text-base font-semibold text-slate-900">{trace.mode}</div>
+          <div className="text-[11px] text-slate-500">Request {trace.request_id}</div>
+        </div>
+        <button
+          type="button"
+          onClick={handleDownload}
+          className="rounded border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+        >
+          Download JSON
+        </button>
+      </div>
+
+      {trace.warnings.length ? (
+        <div className="mt-3 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900">
+          <div className="font-semibold">Warnings</div>
+          <ul className="mt-1 list-disc space-y-0.5 pl-4">
+            {trace.warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <section className="mt-4">
+        <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Planner</div>
+        {trace.planner_steps.length ? (
+          <ol className="mt-2 space-y-2">
+            {trace.planner_steps.map((step) => (
+              <li key={`${step.hop}-${step.subquery}`} className="rounded border border-slate-100 bg-slate-50 p-2">
+                <div className="text-xs font-semibold text-slate-600">{formatHop(step)}</div>
+                {step.notes ? <div className="text-xs text-slate-500">{step.notes}</div> : null}
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className="text-xs text-slate-500">No planner steps recorded.</p>
+        )}
+      </section>
+
+      <section className="mt-4">
+        <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Retrieval hits</div>
+        {trace.retrieval_hits.length ? (
+          <ul className="mt-2 space-y-2">
+            {trace.retrieval_hits.map((hit, idx) => (
+              <li key={`${hit.doc_id ?? "doc"}-${idx}`} className="rounded border border-slate-100 bg-slate-50 p-2">
+                <div className="text-xs text-slate-500">
+                  Rank {hit.rank ?? idx + 1} · {hit.source ?? hit.doc_id ?? "unknown source"}
+                </div>
+                {hit.score !== undefined && hit.score !== null ? (
+                  <div className="text-[11px] text-slate-400">Score {hit.score.toFixed(3)}</div>
+                ) : null}
+                {hit.snippet ? <div className="text-sm text-slate-900">{hit.snippet}</div> : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-xs text-slate-500">Retrieval did not return usable context.</p>
+        )}
+      </section>
+
+      <section className="mt-4 grid gap-3 lg:grid-cols-2">
+        <div className="rounded border border-slate-100 bg-slate-50 p-3">
+          <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Verification</div>
+          {trace.verification ? (
+            <div className="mt-2 text-sm text-slate-900">
+              <div className="font-semibold capitalize">{trace.verification.verdict}</div>
+              {trace.verification.reason ? (
+                <div className="text-xs text-slate-600">{trace.verification.reason}</div>
+              ) : null}
+            </div>
+          ) : (
+            <p className="text-xs text-slate-500">No verification performed.</p>
+          )}
+        </div>
+        <div className="rounded border border-slate-100 bg-slate-50 p-3">
+          <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Synthesis notes</div>
+          {trace.synthesis_notes.length ? (
+            <ul className="mt-2 space-y-1 text-xs text-slate-600">
+              {trace.synthesis_notes.map((note) => (
+                <li key={`${note.step}-${note.notes ?? ""}`}>
+                  <span className="font-semibold">{note.step}:</span> {note.notes ?? "No details."}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-slate-500">No synthesis notes recorded.</p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/lib/__tests__/graphTraceViewer.test.tsx
+++ b/apps/web/lib/__tests__/graphTraceViewer.test.tsx
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToString } from "react-dom/server";
+
+import GraphRagTraceViewer from "../../components/GraphRagTraceViewer";
+import type { GraphRagTrace } from "../../lib/types";
+
+const mockTrace: GraphRagTrace = {
+  request_id: "req-trace",
+  mode: "graph_advanced",
+  planner_steps: [
+    { subquery: "Find PTO policy", hop: 0, notes: "root" },
+    { subquery: "Check security rules", hop: 1 },
+  ],
+  retrieval_hits: [
+    {
+      doc_id: "doc-1",
+      source: "doc-1",
+      score: 0.98,
+      rank: 1,
+      snippet: "Policy snippet",
+    },
+  ],
+  verification: { verdict: "pass", reason: "All evidence aligned." },
+  synthesis_notes: [{ step: "initial_answer", notes: "Merged 2 steps." }],
+  warnings: [],
+};
+
+const html = renderToString(<GraphRagTraceViewer trace={mockTrace} />);
+
+assert(html.includes("graph_advanced"));
+assert(html.includes("Find PTO policy"));
+assert(html.includes("All evidence aligned."));
+
+console.log("✅ Graph trace viewer renders with sample data");

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -142,6 +142,40 @@ export type AdvancedVerificationSummary = {
   notes: string;
 };
 
+export type GraphRagTracePlannerStep = {
+  subquery: string;
+  hop: number;
+  notes?: string | null;
+};
+
+export type GraphRagTraceRetrievalHit = {
+  doc_id?: string | null;
+  source?: string | null;
+  score?: number | null;
+  rank?: number | null;
+  snippet?: string | null;
+};
+
+export type GraphRagTraceVerificationResult = {
+  verdict: string;
+  reason?: string | null;
+};
+
+export type GraphRagTraceSynthesisNote = {
+  step: string;
+  notes?: string | null;
+};
+
+export type GraphRagTrace = {
+  request_id: string;
+  mode: string;
+  planner_steps: GraphRagTracePlannerStep[];
+  retrieval_hits: GraphRagTraceRetrievalHit[];
+  verification?: GraphRagTraceVerificationResult | null;
+  synthesis_notes: GraphRagTraceSynthesisNote[];
+  warnings: string[];
+};
+
 export type AdvancedQueryResponse = {
   session_id: string;
   query: string;
@@ -150,4 +184,5 @@ export type AdvancedQueryResponse = {
   answer: string;
   citations: Array<Record<string, unknown>>;
   verification?: AdvancedVerificationSummary | null;
+  trace?: GraphRagTrace | null;
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test:sanity": "tsx lib/__tests__/modePayload.test.ts && tsx lib/__tests__/apiBaseUrl.test.ts"
+    "test:sanity": "tsx lib/__tests__/modePayload.test.ts && tsx lib/__tests__/apiBaseUrl.test.ts && tsx lib/__tests__/graphTraceViewer.test.tsx"
   },
   "dependencies": {
     "@rag-playground/shared": "workspace:*",


### PR DESCRIPTION
## Summary
- add GraphRagTrace model to API responses and capture planner/retrieval/verification metadata inline with each advanced Graph run
- extend frontend types plus a simple Graph trace viewer with toggle + download support in Graph mode
- add backend/frontend tests validating trace payloads and rendering

## Testing
- cd apps/api && SESSION_SECRET=local-test-secret poetry run pytest -q
- cd apps/web && pnpm install && pnpm --filter web test:sanity