### PR TITLE
GCS ingestion – Milestone 1 (env placeholders)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -46,3 +46,21 @@ GOOGLE_CLIENT_ID=YOUR_GOOGLE_OAUTH_CLIENT_ID_HERE
 ADMIN_GOOGLE_EMAIL=you@example.com
 # SESSION_SECRET must be a long, random string. Do not commit the real value.
 SESSION_SECRET=CHANGE_ME_TO_A_LONG_RANDOM_STRING
+
+# --- GCS-backed ingestion (disabled by default) ---
+
+# If true, the API will treat uploads as GCS-backed instead of pure in-memory.
+# Milestone 1: remains unused (prep only); Milestone 2 will wire it.
+GCS_INGESTION_ENABLED=false
+
+# GCS bucket to use for uploaded raw files and optional derived artifacts.
+# Example: rag-playground-sessions
+GCS_INGESTION_BUCKET=
+
+# Optional prefix under the bucket for session-specific folders.
+# Example: rag-sessions/ (the API will append session IDs).
+GCS_INGESTION_PREFIX=rag-sessions/
+
+# Optional TTL (in days) for lifecycle rules you configure in GCS.
+# NOTE: purely documentation for now; cleanup logic will be wired in a later milestone.
+GCS_INGESTION_TTL_DAYS=7

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -7,3 +7,9 @@ NEXT_PUBLIC_GOOGLE_CLIENT_ID=YOUR_GOOGLE_OAUTH_CLIENT_ID_HERE
 NEXT_PUBLIC_GRAPH_RAG_ENABLED=false
 NEXT_PUBLIC_LLM_RERANK_ENABLED=false
 NEXT_PUBLIC_FACT_CHECK_LLM_ENABLED=false
+
+# --- GCS-backed ingestion (UI hints only, no behavior change yet) ---
+
+# If true, the UI may show that uploads are backed by GCS in diagnostics/help text.
+# Milestone 1: not wired yet; safe to leave as false.
+NEXT_PUBLIC_GCS_INGESTION_ENABLED=false


### PR DESCRIPTION
## Summary
- document backend env placeholders for the upcoming GCS-backed ingestion pipeline
- add matching frontend NEXT_PUBLIC_GCS_INGESTION_ENABLED hint knob

## Notes
- behavior-neutral: no Python or React code paths hook these values yet