### PR TITLE
Fix DaisyUI wiring & playground modes

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -13,8 +13,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   const googleAuthEnabled = process.env.NEXT_PUBLIC_GOOGLE_AUTH_ENABLED?.toLowerCase() === "true";
   const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? "";
   return (
-    <html lang="en">
-      <body className="min-h-screen bg-white text-gray-900 antialiased">
+    <html lang="en" data-theme="light">
+      <body className="min-h-screen bg-base-200 text-base-content antialiased">
         <AuthProvider enabled={googleAuthEnabled} clientId={googleClientId}>
           <div className="flex min-h-screen flex-col">{children}</div>
         </AuthProvider>

--- a/apps/web/app/playground/page.tsx
+++ b/apps/web/app/playground/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState, type SVGProps } from "react";
+import React, { useCallback, useEffect, useState, type SVGProps } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import AdvancedSettings from "../../components/AdvancedSettings";

--- a/apps/web/lib/__tests__/playgroundModes.test.tsx
+++ b/apps/web/lib/__tests__/playgroundModes.test.tsx
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToString } from "react-dom/server";
+
+import Playground from "../../app/playground/page";
+import { AuthProvider } from "../../components/AuthProvider";
+
+function PlaygroundHarness() {
+  return (
+    <AuthProvider enabled={false} clientId="">
+      <Playground />
+    </AuthProvider>
+  );
+}
+
+const html = renderToString(<PlaygroundHarness />);
+
+["Simple", "A/B", "Graph RAG"].forEach((label) => {
+  assert(
+    html.includes(label),
+    `playground UI should render the "${label}" label so modes remain visible`,
+  );
+});
+
+console.log("✅ Playground mode selector renders all required labels");

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test:sanity": "tsx lib/__tests__/modePayload.test.ts && tsx lib/__tests__/apiBaseUrl.test.ts && tsx lib/__tests__/graphTraceViewer.test.tsx && tsx lib/__tests__/storageBackendLabel.test.tsx && tsx lib/__tests__/uploadLimitHint.test.tsx && tsx lib/__tests__/daisyuiComponents.test.tsx"
+    "test:sanity": "tsx lib/__tests__/modePayload.test.ts && tsx lib/__tests__/apiBaseUrl.test.ts && tsx lib/__tests__/graphTraceViewer.test.tsx && tsx lib/__tests__/storageBackendLabel.test.tsx && tsx lib/__tests__/uploadLimitHint.test.tsx && tsx lib/__tests__/daisyuiComponents.test.tsx && tsx lib/__tests__/playgroundModes.test.tsx"
   },
   "dependencies": {
     "@rag-playground/shared": "workspace:*",
@@ -24,6 +24,7 @@
     "@types/react": "18.2.45",
     "@types/react-dom": "18.2.18",
     "autoprefixer": "10.4.17",
+    "daisyui": "^4.12.10",
     "eslint": "8.56.0",
     "eslint-config-next": "14.1.0",
     "postcss": "8.4.35",

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,13 +1,17 @@
 import type { Config } from "tailwindcss";
+import daisyui from "daisyui";
 
 const config: Config = {
   content: [
-    "./app/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{ts,tsx,mdx}",
+    "./components/**/*.{ts,tsx,mdx}",
   ],
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [daisyui],
+  daisyui: {
+    themes: ["light", "dark", "cupcake", "forest"],
+  },
 };
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       autoprefixer:
         specifier: 10.4.17
         version: 10.4.17(postcss@8.4.35)
+      daisyui:
+        specifier: ^4.12.10
+        version: 4.12.24(postcss@8.4.35)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -1456,6 +1459,13 @@ packages:
       which: 2.0.2
     dev: true
 
+  /css-selector-tokenizer@0.8.0:
+    resolution: {integrity: sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==}
+    dependencies:
+      cssesc: 3.0.0
+      fastparse: 1.1.2
+    dev: true
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1464,6 +1474,23 @@ packages:
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  /culori@3.3.0:
+    resolution: {integrity: sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
+  /daisyui@4.12.24(postcss@8.4.35):
+    resolution: {integrity: sha512-JYg9fhQHOfXyLadrBrEqCDM6D5dWCSSiM6eTNCRrBRzx/VlOCrLS8eDfIw9RVvs64v2mJdLooKXY8EwQzoszAA==}
+    engines: {node: '>=16.9.0'}
+    dependencies:
+      css-selector-tokenizer: 0.8.0
+      culori: 3.3.0
+      picocolors: 1.1.1
+      postcss-js: 4.1.0(postcss@8.4.35)
+    transitivePeerDependencies:
+      - postcss
+    dev: true
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -2112,6 +2139,10 @@ packages:
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    dev: true
+
+  /fastparse@1.1.2:
+    resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
     dev: true
 
   /fastq@1.19.1:


### PR DESCRIPTION
Wire DaisyUI into Tailwind, apply a default theme, and add regression tests for the mode selector. No backend/auth/GCS changes.