### PR TITLE
UI – Playground interactive walkthrough

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,6 +4,8 @@ import type { ReactNode } from "react";
 
 import { AuthProvider } from "../components/AuthProvider";
 import SiteNavbar from "../components/SiteNavbar";
+import { TourProvider } from "../components/TourProvider";
+import TourOverlay from "../components/TourOverlay";
 
 export const metadata: Metadata = {
   title: "RAG Playground",
@@ -17,10 +19,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en" data-theme="light">
       <body className="min-h-screen bg-base-200 text-base-content antialiased" data-theme-ready="false">
         <AuthProvider enabled={googleAuthEnabled} clientId={googleClientId}>
-          <div className="flex min-h-screen flex-col">
-            <SiteNavbar />
-            <div className="flex flex-1 flex-col">{children}</div>
-          </div>
+          <TourProvider>
+            <div className="flex min-h-screen flex-col">
+              <SiteNavbar />
+              <div className="flex flex-1 flex-col">{children}</div>
+            </div>
+            <TourOverlay />
+          </TourProvider>
         </AuthProvider>
       </body>
     </html>

--- a/apps/web/app/playground/page.tsx
+++ b/apps/web/app/playground/page.tsx
@@ -12,6 +12,7 @@ import Uploader from "../../components/Uploader";
 import UploadLimitHint from "../../components/UploadLimitHint";
 import SkeletonLine, { SkeletonBlock } from "../../components/Skeletons";
 import { useAuth } from "../../components/AuthProvider";
+import { useTour } from "../../components/TourProvider";
 import { API_BASE } from "../../lib/api";
 import {
   answerFromSnippetsSSE,
@@ -293,6 +294,10 @@ const [queryId, setQueryId] = useState<string | null>(null);
       /* noop */
     });
   }, []);
+  const { startTour } = useTour();
+  useEffect(() => {
+    startTour("playground");
+  }, [startTour]);
 
   const downloadMarkdown = useCallback((value: string, fileName: string) => {
     if (!value) return;
@@ -730,6 +735,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
               <div
                 className="tabs tabs-boxed inline-flex text-sm"
                 role="tablist"
+                data-tour-id="mode-tabs"
                 aria-label="Answer modes"
               >
                 {visibleModeTabs.map((tab) => (
@@ -1106,6 +1112,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
               onClick={doIndex}
               disabled={!canBuild}
               className="btn btn-primary btn-sm w-full"
+              data-tour-id="build-index"
             >
               {busy === "indexing" ? "Indexing…" : "Build index"}
             </button>
@@ -1163,42 +1170,46 @@ const [queryId, setQueryId] = useState<string | null>(null);
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder="e.g., What is our PTO policy?"
                 className="input input-bordered w-full bg-base-100"
+                data-tour-id="query-input"
               />
                 <div className="flex flex-shrink-0 gap-2">
-                  {mode === "simple" ? (
-                    <button
-                      type="button"
-                      onClick={doQuerySimple}
-                      className="btn btn-primary"
-                      disabled={!canQuery}
-                    >
-                      {busy === "querying" ? <LoadingBadge label="Running" /> : "Run"}
-                    </button>
-                  ) : null}
-                  {mode === "advanced" ? (
-                    <button
-                      type="button"
-                      onClick={doCompare}
-                      className="btn btn-primary"
-                      disabled={!canCompare}
-                    >
-                      {busy === "comparing" ? <LoadingBadge label="Comparing" /> : "Run A/B"}
-                    </button>
-                  ) : null}
-                  {mode === "graph" ? (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        void runGraphQuery();
-                      }}
-                      className="btn btn-primary"
-                      disabled={
-                        !authSatisfied || authGateActive || !indexed || !query.trim() || busy === "querying"
-                      }
-                    >
-                      {busy === "querying" ? <LoadingBadge label="Graph RAG" /> : "Run Graph RAG"}
-                    </button>
-                  ) : null}
+                {mode === "simple" ? (
+                  <button
+                    type="button"
+                    onClick={doQuerySimple}
+                    className="btn btn-primary"
+                    disabled={!canQuery}
+                    data-tour-id="run-button"
+                  >
+                    {busy === "querying" ? <LoadingBadge label="Running" /> : "Run"}
+                  </button>
+                ) : null}
+                {mode === "advanced" ? (
+                  <button
+                    type="button"
+                    onClick={doCompare}
+                    className="btn btn-primary"
+                    disabled={!canCompare}
+                    data-tour-id="run-button"
+                  >
+                    {busy === "comparing" ? <LoadingBadge label="Comparing" /> : "Run A/B"}
+                  </button>
+                ) : null}
+                {mode === "graph" ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void runGraphQuery();
+                    }}
+                    className="btn btn-primary"
+                    disabled={
+                      !authSatisfied || authGateActive || !indexed || !query.trim() || busy === "querying"
+                    }
+                    data-tour-id="run-button"
+                  >
+                    {busy === "querying" ? <LoadingBadge label="Graph RAG" /> : "Run Graph RAG"}
+                  </button>
+                ) : null}
                 </div>
               </div>
               {mode !== "graph" ? (
@@ -1215,7 +1226,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
             aria-labelledby="mode-tab-graph"
             className="space-y-4"
           >
-            <div className="card bg-base-100 shadow">
+            <div className="card bg-base-100 shadow" data-tour-id="graph-settings">
               <div className="card-body space-y-4">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <h3 className="card-title text-base text-base-content">Graph RAG answer</h3>
@@ -1252,6 +1263,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
                       onClick={() => setShowGraphTrace((prev) => !prev)}
                       disabled={!graphTrace}
                       className="btn btn-accent btn-xs"
+                      data-tour-id="graph-show-trace"
                     >
                       {showGraphTrace ? "Hide trace" : "Show trace"}
                     </button>
@@ -1341,7 +1353,9 @@ const [queryId, setQueryId] = useState<string | null>(null);
                     )}
                   </div>
                 </div>
-                <FeedbackBar queryId={queryId} />
+                <div data-tour-id="feedback-bar">
+                  <FeedbackBar queryId={queryId} />
+                </div>
               </div>
             </div>
           </div>

--- a/apps/web/components/MetricsDrawer.tsx
+++ b/apps/web/components/MetricsDrawer.tsx
@@ -45,6 +45,7 @@ export default function MetricsDrawer() {
         <button
           className="btn btn-secondary btn-xs"
           onClick={() => setOpen(true)}
+          data-tour-id="metrics-toggle"
         >
           {open ? "Hide metrics" : "Show metrics"}
         </button>

--- a/apps/web/components/ThemeSwitcher.tsx
+++ b/apps/web/components/ThemeSwitcher.tsx
@@ -57,6 +57,7 @@ export default function ThemeSwitcher() {
       <label
         tabIndex={0}
         className="btn btn-ghost btn-sm gap-2"
+        data-tour-id="theme-switcher"
         aria-label="Toggle color theme"
       >
         <span role="img" aria-hidden="true">

--- a/apps/web/components/TourOverlay.tsx
+++ b/apps/web/components/TourOverlay.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { useTour } from "./TourProvider";
+
+type TargetMeta = {
+  rect: DOMRect;
+  isVisible: boolean;
+};
+
+export default function TourOverlay() {
+  const { isActive, currentStep, nextStep, stopTour } = useTour();
+  const [targetMeta, setTargetMeta] = useState<TargetMeta | null>(null);
+
+  useEffect(() => {
+    if (!currentStep) {
+      setTargetMeta(null);
+      return;
+    }
+
+    const element = document.querySelector(currentStep.targetSelector) as HTMLElement | null;
+    if (!element) {
+      if (currentStep.requireVisible) {
+        nextStep();
+      }
+      setTargetMeta(null);
+      return;
+    }
+
+    const rect = element.getBoundingClientRect();
+    setTargetMeta({ rect, isVisible: true });
+  }, [currentStep, nextStep]);
+
+  const cardStyle = useMemo<React.CSSProperties>(() => {
+    if (!targetMeta || typeof window === "undefined") return {};
+    const { rect } = targetMeta;
+    const top = Math.min(window.innerHeight - 180, rect.bottom + 12);
+    const left = Math.min(Math.max(rect.left + rect.width / 2, 180), window.innerWidth - 20);
+    return { top, left };
+  }, [targetMeta]);
+
+  if (!isActive || !currentStep) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-base-300/60 backdrop-blur-sm pointer-events-none" />
+      <div
+        className="fixed z-50 w-[90%] max-w-sm left-1/2 -translate-x-1/2 bottom-4 md:bottom-8"
+        style={targetMeta ? { top: cardStyle.top, left: cardStyle.left, transform: "translate(-50%, 0)" } : undefined}
+      >
+        <div className="card bg-base-100 shadow-xl border border-base-300">
+          <div className="card-body space-y-3">
+            <h3 className="card-title text-sm md:text-base">{currentStep.title}</h3>
+            <p className="text-sm text-base-content/70">{currentStep.body}</p>
+            <div className="card-actions mt-2 justify-between">
+              <button className="btn btn-ghost btn-sm" type="button" onClick={stopTour}>
+                Skip tour
+              </button>
+              <button className="btn btn-primary btn-sm" type="button" onClick={nextStep}>
+                Next
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/components/TourProvider.tsx
+++ b/apps/web/components/TourProvider.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from "react";
+
+export type TourStep = {
+  id: string;
+  targetSelector: string;
+  title: string;
+  body: string;
+  placement?: "top" | "bottom" | "left" | "right";
+  requireVisible?: boolean;
+};
+
+type TourContextValue = {
+  isActive: boolean;
+  currentStepId: string | null;
+  currentStep: TourStep | null;
+  startTour: (tourId: "playground") => void;
+  stopTour: () => void;
+  nextStep: () => void;
+};
+
+const defaultValue: TourContextValue = {
+  isActive: false,
+  currentStepId: null,
+  currentStep: null,
+  startTour: () => {
+    /* noop */
+  },
+  stopTour: () => {
+    /* noop */
+  },
+  nextStep: () => {
+    /* noop */
+  },
+};
+
+const TourContext = createContext<TourContextValue | undefined>(undefined);
+
+const playgroundSteps: TourStep[] = [
+  {
+    id: "mode-tabs",
+    targetSelector: '[data-tour-id="mode-tabs"]',
+    title: "Choose your RAG mode",
+    body:
+      "Start simple, compare A/B retrieval profiles, or switch to Graph RAG to see explainable subqueries and hops.",
+  },
+  {
+    id: "uploader",
+    targetSelector: '[data-tour-id="uploader-dropzone"]',
+    title: "Upload your documents",
+    body:
+      "Drop in your PDFs or text files here, or use the sample dataset to explore the playground quickly.",
+  },
+  {
+    id: "build-index",
+    targetSelector: '[data-tour-id="build-index"]',
+    title: "Build an index",
+    body:
+      "Once your files are uploaded, build an index so the retriever can find relevant passages efficiently.",
+    requireVisible: true,
+  },
+  {
+    id: "query-input",
+    targetSelector: '[data-tour-id="query-input"]',
+    title: "Ask a question",
+    body:
+      "Type a natural-language query—like “What is our PTO policy?”—to run retrieval and generation over your uploaded context.",
+  },
+  {
+    id: "run-button",
+    targetSelector: '[data-tour-id="run-button"]',
+    title: "Run the query",
+    body:
+      "Hit Run to test your retrieval setup. In A/B mode, you can compare two profiles side by side.",
+    requireVisible: true,
+  },
+  {
+    id: "graph-settings",
+    targetSelector: '[data-tour-id="graph-settings"]',
+    title: "Graph RAG settings",
+    body:
+      "Tune hops, top-k, and verification strategy when exploring Graph RAG. This is where you experiment with graph behaviors.",
+    requireVisible: true,
+  },
+  {
+    id: "graph-trace",
+    targetSelector: '[data-tour-id="graph-show-trace"]',
+    title: "Inspect the trace",
+    body:
+      "Use the Graph trace view to see subqueries, hops, and evidence that contributed to the final answer.",
+    requireVisible: true,
+  },
+  {
+    id: "metrics-toggle",
+    targetSelector: '[data-tour-id="metrics-toggle"]',
+    title: "See metrics & history",
+    body:
+      "Open the metrics drawer to inspect recent queries and performance stats—useful when tuning retrieval settings.",
+    requireVisible: true,
+  },
+  {
+    id: "feedback-bar",
+    targetSelector: '[data-tour-id="feedback-bar"]',
+    title: "Collect feedback",
+    body:
+      "Mark answers as helpful or not—this is where you’d wire in user feedback loops in a real production app.",
+    requireVisible: false,
+  },
+];
+
+type TourProviderProps = PropsWithChildren<{
+  initialTourId?: "playground" | null;
+}>;
+
+export function TourProvider({ children, initialTourId = null }: TourProviderProps) {
+  const initialActive = initialTourId === "playground";
+  const [isActive, setIsActive] = useState(initialActive);
+  const [activeTourId, setActiveTourId] = useState<"playground" | null>(
+    initialActive ? "playground" : null,
+  );
+  const [steps, setSteps] = useState<TourStep[]>(() => (initialActive ? playgroundSteps : []));
+  const [currentIndex, setCurrentIndex] = useState<number>(0);
+
+  const currentStep = useMemo(() => {
+    if (!steps.length) return null;
+    return steps[currentIndex] ?? null;
+  }, [steps, currentIndex]);
+
+  const startTour = useCallback((tourId: "playground") => {
+    if (tourId === "playground") {
+      setActiveTourId("playground");
+      setSteps(playgroundSteps);
+      setCurrentIndex(0);
+      setIsActive(true);
+    }
+  }, []);
+
+  const stopTour = useCallback(() => {
+    setIsActive(false);
+    setActiveTourId(null);
+    setSteps([]);
+    setCurrentIndex(0);
+  }, []);
+
+  const nextStep = useCallback(() => {
+    setCurrentIndex((prev) => {
+      const next = prev + 1;
+      if (!steps.length || next >= steps.length) {
+        stopTour();
+        return 0;
+      }
+      return next;
+    });
+  }, [steps.length, stopTour]);
+
+  const value: TourContextValue = {
+    isActive,
+    currentStepId: currentStep?.id ?? null,
+    currentStep,
+    startTour,
+    stopTour,
+    nextStep,
+  };
+
+  return <TourContext.Provider value={value}>{children}</TourContext.Provider>;
+}
+
+export function useTour(): TourContextValue {
+  const ctx = useContext(TourContext);
+  return ctx ?? defaultValue;
+}

--- a/apps/web/components/Uploader.tsx
+++ b/apps/web/components/Uploader.tsx
@@ -54,6 +54,7 @@ export default function Uploader({ disabled, onFilesSelected, onUseSamples }: Pr
         }}
       />
       <div
+        data-tour-id="uploader-dropzone"
         className={`rounded-box border-2 border-dashed ${
           isDragging ? "border-primary bg-primary/5" : "border-base-300 bg-base-200/50"
         } px-4 py-6 text-center text-sm transition hover:border-primary hover:bg-primary/10`}
@@ -90,6 +91,7 @@ export default function Uploader({ disabled, onFilesSelected, onUseSamples }: Pr
       </div>
       <div className="flex flex-wrap gap-2">
         <button
+          data-tour-id="uploader-samples"
           onClick={handleUseSamples}
           disabled={disabled}
           className="btn btn-ghost btn-outline btn-xs sm:btn-sm"

--- a/apps/web/lib/__tests__/playgroundWalkthroughAnchors.test.tsx
+++ b/apps/web/lib/__tests__/playgroundWalkthroughAnchors.test.tsx
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToString } from "react-dom/server";
+
+import Playground from "../../app/playground/page";
+import { TourProvider } from "../../components/TourProvider";
+import { AuthProvider } from "../../components/AuthProvider";
+
+function Harness() {
+  return (
+    <AuthProvider enabled={false} clientId="">
+      <TourProvider>
+        <Playground />
+      </TourProvider>
+    </AuthProvider>
+  );
+}
+
+const html = renderToString(<Harness />);
+
+[
+  "mode-tabs",
+  "uploader-dropzone",
+  "build-index",
+  "query-input",
+  "run-button",
+].forEach((id) => {
+  assert(
+    html.includes(`data-tour-id="${id}"`),
+    `walkthrough anchor ${id} should be present in the playground markup`,
+  );
+});
+
+console.log("✅ Playground walkthrough anchors render as expected");

--- a/apps/web/lib/__tests__/tourProvider.test.tsx
+++ b/apps/web/lib/__tests__/tourProvider.test.tsx
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { TourProvider, useTour } from "../../components/TourProvider";
+
+const html = renderToString(
+  <TourProvider initialTourId="playground">
+    <Status />
+  </TourProvider>,
+);
+
+function Status() {
+  const { isActive, currentStepId } = useTour();
+  return <span data-active={isActive} data-step={currentStepId ?? ""} />;
+}
+
+assert(html.includes('data-active="true"'), "tour should become active after starting");
+assert(html.includes('data-step="mode-tabs"'), "first tour step should be mode-tabs");
+
+console.log("✅ Tour provider starts playground tour at mode-tabs");

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test:sanity": "tsx lib/__tests__/modePayload.test.ts && tsx lib/__tests__/apiBaseUrl.test.ts && tsx lib/__tests__/graphTraceViewer.test.tsx && tsx lib/__tests__/storageBackendLabel.test.tsx && tsx lib/__tests__/uploadLimitHint.test.tsx && tsx lib/__tests__/daisyuiComponents.test.tsx && tsx lib/__tests__/playgroundModes.test.tsx && tsx lib/__tests__/navbarTheme.test.tsx && tsx lib/__tests__/playgroundTabsAccessibility.test.tsx && tsx lib/__tests__/darkThemeButtons.test.tsx"
+    "test:sanity": "tsx lib/__tests__/modePayload.test.ts && tsx lib/__tests__/apiBaseUrl.test.ts && tsx lib/__tests__/graphTraceViewer.test.tsx && tsx lib/__tests__/storageBackendLabel.test.tsx && tsx lib/__tests__/uploadLimitHint.test.tsx && tsx lib/__tests__/daisyuiComponents.test.tsx && tsx lib/__tests__/playgroundModes.test.tsx && tsx lib/__tests__/navbarTheme.test.tsx && tsx lib/__tests__/playgroundTabsAccessibility.test.tsx && tsx lib/__tests__/darkThemeButtons.test.tsx && tsx lib/__tests__/tourProvider.test.tsx && tsx lib/__tests__/playgroundWalkthroughAnchors.test.tsx"
   },
   "dependencies": {
     "@rag-playground/shared": "workspace:*",


### PR DESCRIPTION
## Summary\n- implements a client-side TourProvider + TourOverlay pattern so walkthrough steps can be orchestrated entirely in the web app.\n- adds data-tour-id anchors to the primary playground actions (mode tabs, uploader, build index, query input, run buttons, graph settings/trace, metrics toggle, feedback bar, theme switcher) for robust step targeting.\n- auto-starts the walkthrough on /playground for now; to disable auto-start later, gate  behind a localStorage flag or user setting.\n\n## Testing\n- SESSION_SECRET=local-test-secret poetry run pytest -q\n- pnpm --filter web test:sanity