### PR TITLE
Fix playground layout, walkthrough clarity, and micro-interactions

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -27,6 +27,38 @@ body[data-theme-ready="false"] {
   background-color: hsl(var(--b2) / 0.35);
 }
 
+@layer components {
+  .interactive-card {
+    @apply transition-transform duration-200 ease-out;
+  }
+
+  .interactive-button {
+    @apply transition-transform duration-150 ease-out;
+  }
+
+  .interactive-tab {
+    @apply transition-all duration-150 ease-out;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .interactive-card:hover {
+    @apply -translate-y-0.5 shadow-lg;
+  }
+
+  .interactive-button:hover {
+    @apply -translate-y-0.5 shadow-md brightness-105;
+  }
+
+  .interactive-button:active {
+    transform: scale(0.95);
+  }
+
+  .interactive-tab:hover {
+    @apply -translate-y-0.5;
+  }
+}
+
 /* ---- RAG answer formatting ---- */
 .answer-body {
   white-space: pre-wrap;

--- a/apps/web/app/playground/page.tsx
+++ b/apps/web/app/playground/page.tsx
@@ -685,9 +685,9 @@ const [queryId, setQueryId] = useState<string | null>(null);
 
   return (
     <main className="min-h-[calc(100vh-4rem)] bg-base-200">
-      <div className="mx-auto w-full max-w-7xl px-4 py-8">
+      <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 2xl:max-w-[1400px] py-8">
         <div className="grid grid-cols-12 gap-6">
-      <section className="col-span-12 card card-soft-primary shadow-xl">
+      <section className="col-span-12 card card-soft-primary shadow-xl interactive-card">
         <div className="card-body space-y-6">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div>
@@ -707,7 +707,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
                     {user.is_admin ? <span className="badge badge-success badge-outline">Admin</span> : null}
                     <button
                       onClick={() => signOut()}
-                      className="btn btn-ghost btn-xs"
+                      className="btn btn-ghost btn-xs interactive-button"
                       disabled={authLoading}
                     >
                       Sign out
@@ -717,8 +717,9 @@ const [queryId, setQueryId] = useState<string | null>(null);
                   <button
                     type="button"
                     onClick={() => signIn()}
-                    className="btn btn-primary btn-sm"
+                    className="btn btn-primary btn-sm interactive-button"
                     disabled={authLoading}
+                    data-tour-id="sign-in"
                   >
                     {authLoading ? "Loading…" : (
                       <span className="inline-flex items-center gap-2">
@@ -747,7 +748,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
                     role="tab"
                     aria-selected={mode === tab.value}
                     aria-controls={tab.panelId}
-                    className={`tab whitespace-nowrap ${mode === tab.value ? "tab-active" : ""}`}
+                    className={`tab whitespace-nowrap interactive-tab ${mode === tab.value ? "tab-active" : ""}`}
                     onClick={() => setMode(tab.value)}
                   >
                     {tab.label}
@@ -764,8 +765,8 @@ const [queryId, setQueryId] = useState<string | null>(null);
           </div>
         </div>
       </section>
-      <section className="col-span-12 space-y-4 lg:col-span-6">
-        <div className="card card-soft-secondary shadow">
+      <section className="col-span-12 space-y-4">
+        <div className="card card-soft-secondary shadow interactive-card">
           <div className="card-body space-y-4 text-sm text-base-content">
             <div className="flex items-center justify-between">
               <h3 className="card-title text-base text-base-content">Documents & session</h3>
@@ -802,7 +803,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
             <button
               onClick={doIndex}
               disabled={!canBuild}
-              className="btn btn-primary btn-sm w-full"
+              className="btn btn-primary btn-sm w-full interactive-button"
               data-tour-id="build-index"
             >
               {busy === "indexing" ? "Indexing…" : "Build index"}
@@ -810,8 +811,8 @@ const [queryId, setQueryId] = useState<string | null>(null);
           </div>
         </div>
       </section>
-      <section className="col-span-12 space-y-4 lg:col-span-6">
-        <div className="card card-soft-accent shadow">
+      <section className="col-span-12 space-y-4">
+        <div className="card card-soft-accent shadow interactive-card">
           <div className="card-body space-y-6">
             <div className="space-y-3">
               <div className="flex flex-wrap items-center justify-between gap-3">
@@ -851,7 +852,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
                   <button
                     type="button"
                     onClick={doQuerySimple}
-                    className="btn btn-primary"
+                    className="btn btn-primary interactive-button"
                     disabled={!canQuery}
                     data-tour-id="run-button"
                   >
@@ -862,7 +863,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
                   <button
                     type="button"
                     onClick={doCompare}
-                    className="btn btn-primary"
+                    className="btn btn-primary interactive-button"
                     disabled={!canCompare}
                     data-tour-id="run-button"
                   >
@@ -875,7 +876,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
                     onClick={() => {
                       void runGraphQuery();
                     }}
-                    className="btn btn-primary"
+                    className="btn btn-primary interactive-button"
                     disabled={
                       !authSatisfied || authGateActive || !indexed || !query.trim() || busy === "querying"
                     }
@@ -981,7 +982,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
             aria-labelledby="mode-tab-graph"
             className="space-y-4"
           >
-            <div className="card card-soft-neutral shadow">
+            <div className="card card-soft-neutral shadow interactive-card">
               <div className="card-body space-y-4">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <h3 className="card-title text-base text-base-content">Graph RAG answer</h3>
@@ -1009,7 +1010,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
               </div>
             </div>
             {graphResult ? (
-              <div className="card card-soft-neutral shadow">
+              <div className="card card-soft-neutral shadow interactive-card">
                 <div className="card-body space-y-4 text-sm">
                   <div className="flex items-center justify-between gap-2">
                     <h3 className="card-title text-base text-base-content">Diagnostics</h3>
@@ -1017,7 +1018,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
                       type="button"
                       onClick={() => setShowGraphTrace((prev) => !prev)}
                       disabled={!graphTrace}
-                      className="btn btn-accent btn-xs"
+                      className="btn btn-accent btn-xs interactive-button"
                       data-tour-id="graph-show-trace"
                     >
                       {showGraphTrace ? "Hide trace" : "Show trace"}
@@ -1049,7 +1050,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
                 </div>
               </div>
             ) : isGraphLoading ? (
-              <div className="card card-soft-neutral shadow">
+              <div className="card card-soft-neutral shadow interactive-card">
                 <div className="card-body">
                   <SkeletonBlock lines={4} />
                 </div>
@@ -1060,7 +1061,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
 
         {mode === "simple" ? (
           <div id="mode-panel-simple" role="tabpanel" aria-labelledby="mode-tab-simple">
-            <div className="card card-soft-neutral shadow">
+            <div className="card card-soft-neutral shadow interactive-card">
               <div className="card-body space-y-4">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <h3 className="card-title text-base text-base-content">Answer</h3>
@@ -1118,7 +1119,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
 
         {mode === "advanced" ? (
           <div id="mode-panel-advanced" role="tabpanel" aria-labelledby="mode-tab-advanced">
-            <div className="card card-soft-neutral shadow">
+            <div className="card card-soft-neutral shadow interactive-card">
               <div className="card-body space-y-4">
                 <h3 className="card-title text-base text-base-content">A/B answers</h3>
                 <div className="grid gap-4 md:grid-cols-2">
@@ -1183,7 +1184,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
       </section>
 
         {mode === "advanced" ? (
-          <section className="col-span-12 card card-soft-secondary shadow">
+          <section className="col-span-12 card card-soft-secondary shadow interactive-card">
             <div className="card-body space-y-3">
               <h3 className="card-title text-base text-base-content">Profiles (A/B)</h3>
               <AdvancedSettings
@@ -1195,7 +1196,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
           </section>
         ) : null}
 
-        <section className="col-span-12 card card-soft-neutral shadow">
+        <section className="col-span-12 card card-soft-neutral shadow interactive-card">
           <div className="card-body space-y-4 text-sm text-base-content">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
@@ -1270,7 +1271,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
         </div>
       </section>
       {authEnabled ? (
-        <section className="col-span-12 card card-soft-neutral shadow">
+        <section className="col-span-12 card card-soft-neutral shadow interactive-card">
           <div className="card-body space-y-3 text-sm text-base-content">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
@@ -1316,7 +1317,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
       ) : null}
 
       {authEnabled && user?.is_admin ? (
-        <section className="col-span-12 card card-soft-neutral shadow">
+        <section className="col-span-12 card card-soft-neutral shadow interactive-card">
           <div className="card-body space-y-4 text-sm text-base-content">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <h2 className="card-title text-base text-base-content">Admin tools</h2>
@@ -1433,7 +1434,7 @@ const [queryId, setQueryId] = useState<string | null>(null);
 
       {mode === "simple" ? (
         <aside className="col-span-12 space-y-4 lg:col-span-3">
-          <div className="card card-soft-neutral shadow">
+          <div className="card card-soft-neutral shadow interactive-card">
             <div className="card-body space-y-3 text-sm text-base-content">
               <div className="flex items-center justify-between">
                 <h3 className="card-title text-base text-base-content">Explainability</h3>

--- a/apps/web/components/AuthProvider.tsx
+++ b/apps/web/components/AuthProvider.tsx
@@ -211,8 +211,12 @@ export function AuthProvider({ children, enabled, clientId }: AuthProviderProps)
   );
 }
 
+export function useOptionalAuth(): AuthContextValue | null {
+  return useContext(AuthContext) ?? null;
+}
+
 export function useAuth(): AuthContextValue {
-  const ctx = useContext(AuthContext);
+  const ctx = useOptionalAuth();
   if (!ctx) {
     throw new Error('useAuth must be used within an AuthProvider');
   }

--- a/apps/web/components/GraphRagTraceViewer.tsx
+++ b/apps/web/components/GraphRagTraceViewer.tsx
@@ -35,7 +35,7 @@ export default function GraphRagTraceViewer({ trace }: Props) {
 
   return (
     <div className="space-y-4 text-sm text-base-content">
-      <div className="card bg-base-100 shadow">
+      <div className="card bg-base-100 shadow interactive-card">
         <div className="card-body flex flex-wrap items-center justify-between gap-3">
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-base-content/60">Trace</p>
@@ -45,7 +45,7 @@ export default function GraphRagTraceViewer({ trace }: Props) {
           <button
             type="button"
             onClick={handleDownload}
-            className="btn btn-ghost btn-outline btn-xs"
+            className="btn btn-ghost btn-outline btn-xs interactive-button"
           >
             Download JSON
           </button>
@@ -73,7 +73,9 @@ export default function GraphRagTraceViewer({ trace }: Props) {
                 <div key={`${step.hop}-${step.subquery}`} className="rounded-box border border-base-200 bg-base-200/60 p-3">
                   <div className="flex items-center justify-between text-xs font-semibold">
                     <span>{formatHop(step)}</span>
-                    <span className="badge badge-primary badge-outline">Hop {step.hop + 1}</span>
+                    <span className="badge badge-primary badge-outline whitespace-nowrap px-3 py-1 text-xs font-semibold">
+                      Hop {step.hop + 1}
+                    </span>
                   </div>
                   {step.notes ? <div className="text-xs text-base-content/70">{step.notes}</div> : null}
                 </div>
@@ -93,7 +95,7 @@ export default function GraphRagTraceViewer({ trace }: Props) {
                 <div key={`${hit.doc_id ?? "doc"}-${idx}`} className="rounded-box border border-base-200 bg-base-200/60 p-3">
                   <div className="flex items-center justify-between text-xs">
                     <span className="font-semibold">{hit.source ?? hit.doc_id ?? "unknown source"}</span>
-                    <span className="badge badge-secondary badge-outline">
+                    <span className="badge badge-secondary badge-outline whitespace-nowrap px-3 py-1 text-xs font-semibold">
                       Rank {hit.rank ?? idx + 1}
                     </span>
                   </div>
@@ -111,7 +113,7 @@ export default function GraphRagTraceViewer({ trace }: Props) {
       </div>
 
       <div className="grid gap-4 lg:grid-cols-2">
-        <div className="card bg-base-100 shadow-sm">
+        <div className="card bg-base-100 shadow-sm interactive-card">
           <div className="card-body space-y-2">
             <div className="flex items-center justify-between">
               <p className="text-xs font-semibold uppercase text-base-content/60">Verification</p>
@@ -134,7 +136,7 @@ export default function GraphRagTraceViewer({ trace }: Props) {
             )}
           </div>
         </div>
-        <div className="card bg-base-100 shadow-sm">
+        <div className="card bg-base-100 shadow-sm interactive-card">
           <div className="card-body space-y-2">
             <div className="text-xs font-semibold uppercase text-base-content/60">Synthesis notes</div>
             {trace.synthesis_notes.length ? (

--- a/apps/web/components/MetricsDrawer.tsx
+++ b/apps/web/components/MetricsDrawer.tsx
@@ -43,7 +43,7 @@ export default function MetricsDrawer() {
       />
       <div className="drawer-content">
         <button
-          className="btn btn-secondary btn-xs"
+          className="btn btn-secondary btn-xs interactive-button"
           onClick={() => setOpen(true)}
           data-tour-id="metrics-toggle"
         >
@@ -63,7 +63,7 @@ export default function MetricsDrawer() {
               <div className="flex items-center justify-between">
                 <h3 className="card-title text-base">Recent metrics</h3>
                 <button
-                  className="btn btn-secondary btn-sm"
+                  className="btn btn-secondary btn-sm interactive-button"
                   onClick={() => setOpen(false)}
                 >
                   Close

--- a/apps/web/components/TourOverlay.tsx
+++ b/apps/web/components/TourOverlay.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useTour } from "./TourProvider";
 
 type TargetMeta = {
   rect: DOMRect;
-  isVisible: boolean;
 };
 
 export default function TourOverlay() {
   const { isActive, currentStep, nextStep, stopTour } = useTour();
   const [targetMeta, setTargetMeta] = useState<TargetMeta | null>(null);
+  const previousStepId = useRef<string | null>(null);
 
   useEffect(() => {
     if (!currentStep) {
@@ -18,25 +18,77 @@ export default function TourOverlay() {
       return;
     }
 
-    const element = document.querySelector(currentStep.targetSelector) as HTMLElement | null;
-    if (!element) {
-      if (currentStep.requireVisible) {
-        nextStep();
+    const updateMeta = () => {
+      const element = document.querySelector(currentStep.targetSelector) as HTMLElement | null;
+      if (!element) {
+        if (currentStep.requireVisible) {
+          nextStep();
+        }
+        setTargetMeta(null);
+        return;
       }
-      setTargetMeta(null);
-      return;
-    }
 
-    const rect = element.getBoundingClientRect();
-    setTargetMeta({ rect, isVisible: true });
+      const rect = element.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) {
+        if (currentStep.requireVisible) {
+          nextStep();
+        }
+        setTargetMeta(null);
+        return;
+      }
+
+      if (previousStepId.current !== currentStep.id) {
+        element.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
+        previousStepId.current = currentStep.id;
+      }
+
+      setTargetMeta({ rect });
+    };
+
+    updateMeta();
+    window.addEventListener("resize", updateMeta);
+    window.addEventListener("scroll", updateMeta, true);
+    return () => {
+      window.removeEventListener("resize", updateMeta);
+      window.removeEventListener("scroll", updateMeta, true);
+    };
   }, [currentStep, nextStep]);
 
   const cardStyle = useMemo<React.CSSProperties>(() => {
-    if (!targetMeta || typeof window === "undefined") return {};
+    if (!targetMeta || typeof window === "undefined") {
+      return {};
+    }
+
+    const cardWidth = Math.min(360, window.innerWidth - 32);
+    const cardHeight = 190;
     const { rect } = targetMeta;
-    const top = Math.min(window.innerHeight - 180, rect.bottom + 12);
-    const left = Math.min(Math.max(rect.left + rect.width / 2, 180), window.innerWidth - 20);
-    return { top, left };
+    const canShowBelow = rect.bottom + cardHeight + 16 <= window.innerHeight;
+    const top = canShowBelow
+      ? rect.bottom + 16
+      : Math.max(16, rect.top - cardHeight - 16);
+    const left = Math.min(
+      Math.max(rect.left + rect.width / 2 - cardWidth / 2, 16),
+      window.innerWidth - cardWidth - 16,
+    );
+    return { top, left, width: cardWidth };
+  }, [targetMeta]);
+
+  const highlightStyle = useMemo<React.CSSProperties | undefined>(() => {
+    if (!targetMeta || typeof window === "undefined") return undefined;
+    const padding = 12;
+    const width = Math.min(targetMeta.rect.width + padding * 2, window.innerWidth - 16);
+    const height = Math.min(targetMeta.rect.height + padding * 2, window.innerHeight - 16);
+    const top = Math.max(targetMeta.rect.top - padding, 8);
+    const left = Math.max(targetMeta.rect.left - padding, 8);
+    return {
+      top,
+      left,
+      width,
+      height,
+      borderRadius: 12,
+      boxShadow: "0 0 0 9999px rgba(15, 23, 42, 0.55)",
+      border: "2px solid hsl(var(--p) / 0.8)",
+    };
   }, [targetMeta]);
 
   if (!isActive || !currentStep) {
@@ -45,10 +97,21 @@ export default function TourOverlay() {
 
   return (
     <>
-      <div className="fixed inset-0 z-40 bg-base-300/60 backdrop-blur-sm pointer-events-none" />
+      {highlightStyle ? (
+        <div
+          className="pointer-events-none fixed z-40 transition-all duration-200"
+          style={highlightStyle}
+        />
+      ) : (
+        <div className="pointer-events-none fixed inset-0 z-40 bg-base-300/50" />
+      )}
       <div
-        className="fixed z-50 w-[90%] max-w-sm left-1/2 -translate-x-1/2 bottom-4 md:bottom-8"
-        style={targetMeta ? { top: cardStyle.top, left: cardStyle.left, transform: "translate(-50%, 0)" } : undefined}
+        className="fixed z-50 w-[90%] max-w-sm"
+        style={
+          targetMeta
+            ? cardStyle
+            : { left: "50%", transform: "translateX(-50%)", bottom: 32 }
+        }
       >
         <div className="card bg-base-100 shadow-xl border border-base-300">
           <div className="card-body space-y-3">

--- a/apps/web/components/Uploader.tsx
+++ b/apps/web/components/Uploader.tsx
@@ -94,14 +94,14 @@ export default function Uploader({ disabled, onFilesSelected, onUseSamples }: Pr
           data-tour-id="uploader-samples"
           onClick={handleUseSamples}
           disabled={disabled}
-          className="btn btn-ghost btn-outline btn-xs sm:btn-sm"
+          className="btn btn-ghost btn-outline btn-xs sm:btn-sm interactive-button"
         >
           {busy ? "Loading…" : "Use sample dataset"}
         </button>
         <button
           onClick={handlePick}
           disabled={disabled || busy}
-          className="btn btn-secondary btn-xs sm:btn-sm"
+          className="btn btn-secondary btn-xs sm:btn-sm interactive-button"
         >
           Browse files
         </button>

--- a/apps/web/lib/__tests__/graphTraceViewer.test.tsx
+++ b/apps/web/lib/__tests__/graphTraceViewer.test.tsx
@@ -32,5 +32,8 @@ assert(html.includes("graph_advanced"));
 assert(html.includes("collapse"), "trace viewer should include collapsible sections");
 assert(html.includes("badge"), "trace viewer should include DaisyUI badges");
 assert(html.includes("All evidence aligned."));
+const normalizedHtml = html.replace(/<!--.*?-->/g, "").replace(/&nbsp;/g, " ");
+assert(normalizedHtml.includes("Hop 1"), "planner hop badge should display without truncation");
+assert(normalizedHtml.includes("Rank 1"), "retrieval rank badge should display without truncation");
 
 console.log("✅ Graph trace viewer renders with sample data");

--- a/apps/web/lib/__tests__/playgroundInteractiveButtons.test.tsx
+++ b/apps/web/lib/__tests__/playgroundInteractiveButtons.test.tsx
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToString } from "react-dom/server";
+
+import Playground from "../../app/playground/page";
+import { AuthProvider } from "../../components/AuthProvider";
+import { TourProvider } from "../../components/TourProvider";
+
+const html = renderToString(
+  <AuthProvider enabled={false} clientId="">
+    <TourProvider>
+      <Playground />
+    </TourProvider>
+  </AuthProvider>,
+);
+
+function expectInteractive(dataAttr: string) {
+  const pattern = new RegExp(`${dataAttr}[\\s\\S]{0,120}interactive-button`);
+  assert(
+    pattern.test(html),
+    `button with ${dataAttr} should include interactive-button class`,
+  );
+}
+
+expectInteractive('data-tour-id="run-button"');
+expectInteractive('data-tour-id="build-index"');
+
+console.log("✅ Playground key buttons include interactive hover styles");

--- a/apps/web/lib/__tests__/tourProvider.test.tsx
+++ b/apps/web/lib/__tests__/tourProvider.test.tsx
@@ -3,18 +3,32 @@ import React from "react";
 import { renderToString } from "react-dom/server";
 import { TourProvider, useTour } from "../../components/TourProvider";
 
+function Status() {
+  const { isActive, currentStepId } = useTour();
+  return <span data-active={isActive} data-step={currentStepId ?? ""} />;
+}
+
 const html = renderToString(
   <TourProvider initialTourId="playground">
     <Status />
   </TourProvider>,
 );
 
-function Status() {
-  const { isActive, currentStepId } = useTour();
-  return <span data-active={isActive} data-step={currentStepId ?? ""} />;
-}
-
 assert(html.includes('data-active="true"'), "tour should become active after starting");
-assert(html.includes('data-step="mode-tabs"'), "first tour step should be mode-tabs");
+assert(html.includes('data-step="mode-tabs"'), "first tour step should be mode-tabs when auth disabled");
 
-console.log("✅ Tour provider starts playground tour at mode-tabs");
+const htmlWithSignIn = renderToString(
+  <TourProvider
+    initialTourId="playground"
+    authStateOverride={{ authEnabled: true, isAuthenticated: false }}
+  >
+    <Status />
+  </TourProvider>,
+);
+
+assert(
+  htmlWithSignIn.includes('data-step="sign-in"'),
+  "tour should start with sign-in step when auth is enabled but user is signed out",
+);
+
+console.log("✅ Tour provider adapts starting step to auth state");


### PR DESCRIPTION
## Summary\n- widen the playground container, stack Documents & session above Ask a question, and refresh card pastels so the page fills more of the viewport\n- enhance the guided tour with a conditional sign-in step plus spotlighted anchors so targets stay crisp while the rest dims\n- add small motion helpers for priority buttons/tabs/cards, fix Graph RAG hop/rank badges, and keep Build/Run buttons under interactive regression tests\n\nCloses #18