### PR TITLE
Switch themes to DaisyUI pastel + dark

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   const googleAuthEnabled = process.env.NEXT_PUBLIC_GOOGLE_AUTH_ENABLED?.toLowerCase() === "true";
   const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? "";
   return (
-    <html lang="en" data-theme="light">
+    <html lang="en" data-theme="pastel">
       <body className="min-h-screen bg-base-200 text-base-content antialiased" data-theme-ready="false">
         <AuthProvider enabled={googleAuthEnabled} clientId={googleClientId}>
           <TourProvider>

--- a/apps/web/components/ThemeSwitcher.tsx
+++ b/apps/web/components/ThemeSwitcher.tsx
@@ -3,29 +3,39 @@
 import React, { useEffect, useMemo, useState } from "react";
 
 const THEME_OPTIONS = [
-  { value: "light", label: "Daylight", subtitle: "Light", icon: "☀️" },
-  { value: "forest", label: "Forest", subtitle: "Dark", icon: "🌲" },
+  { value: "pastel", label: "Pastel", subtitle: "Soft & light", icon: "🎨" },
+  { value: "dark", label: "Dark", subtitle: "High contrast", icon: "🌙" },
 ] as const;
 
 type ThemeName = (typeof THEME_OPTIONS)[number]["value"];
+const FALLBACK_THEME: ThemeName = "pastel";
 
 const STORAGE_KEY = "rag-playground-theme";
+
+function normalizeTheme(value: string | null): ThemeName | null {
+  if (!value) return null;
+  const lower = value.toLowerCase();
+  if (lower === "pastel") return "pastel";
+  if (lower === "dark") return "dark";
+  if (lower === "light" || lower === "daylight") return "pastel";
+  if (lower === "forest") return "dark";
+  return null;
+}
 
 function getStoredTheme(): ThemeName | null {
   if (typeof window === "undefined") return null;
   const stored = window.localStorage.getItem(STORAGE_KEY);
-  const match = THEME_OPTIONS.find((option) => option.value === stored);
-  return match ? match.value : null;
+  return normalizeTheme(stored);
 }
 
 function resolveInitialTheme(): ThemeName {
   const stored = getStoredTheme();
   if (stored) return stored;
-  return "light";
+  return FALLBACK_THEME;
 }
 
 export default function ThemeSwitcher() {
-  const [theme, setTheme] = useState<ThemeName>("light");
+  const [theme, setTheme] = useState<ThemeName>(FALLBACK_THEME);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -47,6 +57,11 @@ export default function ThemeSwitcher() {
     return current ? `${current.icon} ${current.label}` : "Theme";
   }, [theme]);
 
+  const selectedIcon = useMemo(() => {
+    const current = THEME_OPTIONS.find((option) => option.value === theme);
+    return current?.icon ?? "🎨";
+  }, [theme]);
+
   return (
     <div className="dropdown dropdown-end" data-testid="theme-switcher">
       <label
@@ -56,7 +71,7 @@ export default function ThemeSwitcher() {
         aria-label="Toggle color theme"
       >
         <span role="img" aria-hidden="true">
-          {theme === "forest" ? "🌙" : "☀️"}
+          {selectedIcon}
         </span>
         <span className="hidden sm:inline">{mounted ? selectedLabel : "Theme"}</span>
       </label>

--- a/apps/web/lib/__tests__/darkThemeButtons.test.tsx
+++ b/apps/web/lib/__tests__/darkThemeButtons.test.tsx
@@ -16,7 +16,7 @@ function PlaygroundHarness() {
 }
 
 const html = renderToString(
-  <div data-theme="forest">
+  <div data-theme="dark">
     <PlaygroundHarness />
   </div>,
 );

--- a/apps/web/lib/__tests__/navbarTheme.test.tsx
+++ b/apps/web/lib/__tests__/navbarTheme.test.tsx
@@ -10,7 +10,7 @@ assert(
   html.includes('data-testid="theme-switcher"'),
   "navbar should render the theme switcher control",
 );
-["Daylight", "Forest"].forEach((label) => {
+["Pastel", "Dark"].forEach((label) => {
   assert(html.includes(label), `theme switcher should list the ${label} theme`);
 });
 

--- a/apps/web/lib/__tests__/themeDefault.test.tsx
+++ b/apps/web/lib/__tests__/themeDefault.test.tsx
@@ -7,7 +7,7 @@ import { createRoot } from "react-dom/client";
 import ThemeSwitcher from "../../components/ThemeSwitcher";
 
 async function runTest() {
-const dom = new JSDOM("<!doctype html><html data-theme=\"light\"><body><div id=\"root\"></div></body></html>", {
+const dom = new JSDOM("<!doctype html><html data-theme=\"pastel\"><body><div id=\"root\"></div></body></html>", {
   pretendToBeVisual: true,
   url: "https://example.com",
 });
@@ -29,8 +29,29 @@ const dom = new JSDOM("<!doctype html><html data-theme=\"light\"><body><div id=\
 
   assert.strictEqual(
     window.document.documentElement.dataset.theme,
-    "light",
-    "ThemeSwitcher should default to light when no preference is stored",
+    "pastel",
+    "ThemeSwitcher should default to pastel when no preference is stored",
+  );
+  const bodyText = window.document.body.textContent ?? "";
+  ["Pastel", "Dark"].forEach((label) => {
+    assert(
+      bodyText.includes(label),
+      `theme switcher should list the ${label} option`,
+    );
+  });
+
+  const darkButton = Array.from(window.document.querySelectorAll("button")).find((btn) =>
+    btn.textContent?.includes("Dark"),
+  );
+  assert(darkButton, "Dark option button should render");
+  await act(async () => {
+    darkButton!.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  assert.strictEqual(
+    window.document.documentElement.dataset.theme,
+    "dark",
+    "Switching to Dark should update the root dataset theme",
   );
 
   root.unmount();
@@ -40,7 +61,7 @@ const dom = new JSDOM("<!doctype html><html data-theme=\"light\"><body><div id=\
   delete (globalThis as any).navigator;
   delete (globalThis as any).localStorage;
 
-  console.log("✅ ThemeSwitcher defaults to Daylight when no saved theme is present");
+  console.log("✅ ThemeSwitcher defaults to Pastel and toggles to Dark");
 }
 
 void runTest();

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -11,29 +11,7 @@ const config: Config = {
   },
   plugins: [daisyui],
   daisyui: {
-    themes: [
-      "light",
-      {
-        forest: {
-          primary: "#22d3ee",
-          "primary-content": "#03151c",
-          secondary: "#a78bfa",
-          "secondary-content": "#120926",
-          accent: "#f472b6",
-          "accent-content": "#1f0c18",
-          neutral: "#1f2937",
-          "neutral-content": "#f5f7fa",
-          "base-100": "#121721",
-          "base-200": "#0d121b",
-          "base-300": "#1f2933",
-          "base-content": "#f5f7fa",
-          info: "#38bdf8",
-          success: "#4ade80",
-          warning: "#facc15",
-          error: "#f87171",
-        },
-      },
-    ],
+    themes: ["pastel", "dark"],
   },
 };
 export default config;


### PR DESCRIPTION
## Summary\n- swap the exposed Daylight/Forest pair for DaisyUI's built-in Pastel + Dark themes (tailwind config + ThemeSwitcher)\n- default layout now starts in Pastel and legacy theme values gracefully remap to the new set\n- no backend logic touched\n\n## Testing\n- [x] cd apps/api && SESSION_SECRET=local-test-secret poetry run pytest -q\n- [x] cd apps/web && pnpm install\n- [x] cd apps/web && pnpm --filter web test:sanity